### PR TITLE
Omit arrows by setting 0 length

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # geomtextpath (development version)
 
-No changes yet.
+* Fixed a bug in the windows graphics device when using arrows (#66).
 
 # geomtextpath 0.1.0
 

--- a/R/path_handling.R
+++ b/R/path_handling.R
@@ -248,17 +248,17 @@ tailor_arrow <- function(data, arrow) {
   arrow[] <- lapply(arrow, function(x) {
     x[pmin(id, length(x))]
   })
-  angle <- arrow$angle
   ends  <- arrow$ends
+  lens  <- arrow$length
 
   # Ends are 1 = "first", 2 = "last", 3 = "both".
-  # We 'hide' an arrow by setting an NA angle
-  angle[ends == 2 & sides == "pre"]  <- NA_integer_
-  angle[ends == 1 & sides == "post"] <- NA_integer_
-  ends[ends == 3 & sides == "pre"]   <- 1L
-  ends[ends == 3 & sides == "post"]  <- 2L
-  arrow$angle <- angle
-  arrow$ends  <- ends
+  # We 'hide' an arrow by setting a zero length
+  lens[ends == 2 & sides == "pre"]  <- unit(0, "pt")
+  lens[ends == 1 & sides == "post"] <- unit(0, "pt")
+  ends[ends == 3 & sides == "pre"]  <- 1L
+  ends[ends == 3 & sides == "post"] <- 2L
+  arrow$ends   <- ends
+  arrow$length <- lens
   arrow
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -186,22 +186,22 @@ test_that("arrows are expanded correctly", {
 
   test <- tailor_arrow(data, arrow(ends = "last"))
   # Angle should be NA when section is 'pre'
-  expect_equal(test$angle, c(NA, 30, NA, 30, 30))
+  expect_equal(as.numeric(test$length), c(0, 0.25, 0, 0.25, 0.25))
   expect_equal(test$ends, rep(2L, 5))
 
   test <- tailor_arrow(data, arrow(ends = "first"))
   # Angle should be NA when section is 'post'
-  expect_equal(test$angle, c(30, NA, 30, NA, 30))
+  expect_equal(as.numeric(test$length), c(0.25, 0, 0.25, 0, 0.25))
   expect_equal(test$ends, rep(1L, 5))
 
   # Angles should be preserved, but ends should be set correctly
   test <- tailor_arrow(data, arrow(ends = "both"))
-  expect_equal(test$angle, rep(30, 5))
+  expect_equal(as.numeric(test$length), rep(0.25, 5))
   expect_equal(test$ends, c(1L, 2L, 1L, 2L, 3L))
 
   # Test that we can use a mix of ends
   test <- tailor_arrow(data, arrow(ends = c("first", "last", "first")))
-  expect_equal(test$angle, c(30, NA, NA, 30, 30))
+  expect_equal(as.numeric(test$length), c(0.25, 0, 0, 0.25, 0.25))
   expect_equal(test$ends, c(1L, 1L, 2L, 2L, 1L))
 })
 


### PR DESCRIPTION
This PR aims to fix #66.
At the CI of my fork it failed on mac due to not being able to configure {sf}. This doesn't seem related to the code changes I made, so this can be merged now or we could try to figure out what is going on with sf.