### PR TITLE
Change the `fragment_only` option to `-standalone`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     roxygen2,
     sf,
     xml2,
-    markdown
+    markdown (>= 1.3)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Collate: 

--- a/R/text_helpers.R
+++ b/R/text_helpers.R
@@ -318,7 +318,7 @@ parse_richtext <- function(
 
   if (md) {
     text <- markdown::markdownToHTML(text = text,
-              options = c("use_xhtml", "fragment_only"))
+              options = "-standalone")
 
   }
   # Deal with <br> now, they are a pain to handle after parsing

--- a/R/text_helpers.R
+++ b/R/text_helpers.R
@@ -317,9 +317,7 @@ parse_richtext <- function(
   old_gp <- gp
 
   if (md) {
-    text <- markdown::markdownToHTML(text = text,
-              options = "-standalone")
-
+    text <- markdown::mark_html(text = text, options = "-standalone")
   }
   # Deal with <br> now, they are a pain to handle after parsing
   text <- gsub("<br>", "\n", text, fixed = TRUE)


### PR DESCRIPTION
This option will be renamed in the next version of the **markdown** package.

Please do not merge this PR yet. I'll let you know when the next version of **markdown** is on CRAN. There will be no hurry to merge since I've made it backward-compatible, but in the long run, I might drop this `fragment_only` option.

Thank you very much!