### PR TITLE
Update for ggplot2 3.5.0

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -341,8 +341,11 @@ get_polar_params <- function(coord, params) {
   if (inherits(coord, "CoordPolar")) {
     list(x = 0.5, y = 0.5, theta = coord$theta)
   } else if (inherits(coord, "CoordRadial")) {
-    data <- coord$transform(data.frame(x = -Inf, y = -Inf), params)
-    list(x = data$x, y = data$y, theta = coord$theta)
+    list(
+      x = rescale(0.5, from = params$bbox$x),
+      y = rescale(0.5, from = params$bbox$y),
+      theta = coord$theta
+    )
   } else {
     NULL
   }

--- a/tests/testthat/test-coord_curvedpolar.R
+++ b/tests/testthat/test-coord_curvedpolar.R
@@ -68,8 +68,10 @@ test_that("wrapping first and last labels works as expected", {
 
   expect_equal(axis_labels$textpath$label[[9]]$glyph, c("1", "/", "1", "0"))
 
-  out <- ggplot_gtable(ggplot_build(p + scale_x_continuous(breaks = 1:10,
-                                                      labels = as.expression)))
+  out <- ggplot_gtable(ggplot_build(
+    p + scale_x_continuous(breaks = seq(1, 10, by = 1),
+                           labels = as.expression)
+  ))
   panel <- out$grobs[[which(out$layout$name == "panel")]]
   axis_labels <- panel$children[[5]]$children[[1]]
 


### PR DESCRIPTION
Hi Allan,

This PR updates geomtextpath so that it doesn't fail tests against dev ggplot2 anymore.
I also improved the `get_polar_params()` function (again).
There is some scale stuff that throws some deprecation warnings, but we probably needn't bother with this unless we update the required ggplot2 version.

Happy holidays!